### PR TITLE
feat: update facebook advertisers extraction and allow literal index …

### DIFF
--- a/src/framework/processing/py/port/flows/common.py
+++ b/src/framework/processing/py/port/flows/common.py
@@ -258,29 +258,28 @@ def zip_to_data_tables(zip_file: str, tables: list) -> list[DataTable]:
     out: list[DataTable] = []
     try:
         file = zipfile.ZipFile(zip_file)
-        target_files = [table["filename"] for table in tables]
-        for name in file.namelist():
-            if not name in target_files:
+        # Since each file can create multiple tables, iterate over the tables
+        # and check if the file exists in the zip archive
+        for table in tables:
+            target_filename = table["filename"]
+            if target_filename not in file.namelist():
                 continue
-            target_table = next((table for table in tables if table["filename"] == name), None)
-            with file.open(name) as json_file:
+            with file.open(target_filename) as json_file:
                 ad_pref_dict = json.load(json_file)
                 # Flatten the JSON data
                 flattened_data = flatten_json.flatten(ad_pref_dict, verbose=False)
                 # Map the flattened data to the desired structure
                 mapped_data = map_json.map_json(flattened_data, 
-                                                create_mapping_from_columns(target_table["columns"]), 
+                                                create_mapping_from_columns(table["columns"]), 
                                                 verbose=False)
                 # Convert to pandas DataFrame
                 df = pd.DataFrame(mapped_data.get("rows", []))
                 out.append(DataTable(
-                    name=props.Translatable({"en": target_table["name"]}),
+                    name=props.Translatable({"en": table["name"]}),
                     data_frame=df
                 ))
 
     except Exception as e:
         print(f"Something went wrong: {e}")
-
-    print(f"Created {len(out)} data tables:", out)
 
     return out

--- a/src/framework/processing/py/port/flows/facebook.py
+++ b/src/framework/processing/py/port/flows/facebook.py
@@ -42,12 +42,12 @@ tables = [
         "name": "Ad interests",
         "columns": [
             {
-                "from": "label_values.[-1].dict.[i].dict.[0].value",
+                "from": "label_values.[28].dict.[i].dict.[0].value",
                 "field": "value",
                 "name": "Value",
             },
             {
-                "from": "label_values.[-1].dict.[i].dict.[0].label",
+                "from": "label_values.[28].dict.[i].dict.[0].label",
                 "field": "label",
                 "name": "Label",
             }
@@ -55,27 +55,23 @@ tables = [
     },
     {
         "filename": "ads_information/advertisers_using_your_activity_or_information.json",
-        "name": "Advertisers using your activity or information",
+        "name": "A list uploaded or used by the advertiser",
         "columns": [
             {
-                "from": "custom_audiences_all_types_v2.[i].advertiser_name",
-                "field": "advertiser_name",
+                "from": "label_values.[0].vec.[i].value",
+                "field": "value",
                 "name": "Advertiser Name",
-            },
+            }
+        ]
+    },
+    {
+        "filename": "ads_information/advertisers_using_your_activity_or_information.json",
+        "name": "Interactions you may have had with the advertiser's website, app or store",
+        "columns": [
             {
-                "from": "custom_audiences_all_types_v2.[i].has_data_file_custom_audience",
-                "field": "has_data_file_custom_audience",
-                "name": "Has Data File Custom Audience",
-            },
-            {
-                "from": "custom_audiences_all_types_v2.[i].has_remarketing_custom_audience",
-                "field": "has_remarketing_custom_audience",
-                "name": "Has Remarketing Custom Audience",
-            },
-            {
-                "from": "custom_audiences_all_types_v2.[i].has_in_person_store_visit",
-                "field": "has_in_person_store_visit",
-                "name": "Has In-Person Store Visit",
+                "from": "label_values.[1].vec.[i].value",
+                "field": "value",
+                "name": "Advertiser Name",
             }
         ]
     },

--- a/src/framework/processing/py/port/flows/utils/flat_json/map_json.py
+++ b/src/framework/processing/py/port/flows/utils/flat_json/map_json.py
@@ -27,6 +27,11 @@ def create_regex_from_path(path):
     indices = re.findall(r'\[([^\]]+)\]', path)
     # Replace the indices with a regex pattern that matches any string
     for index in indices:
+        # If an actual number is given, leave it as is so it can be matched literally
+        is_number = re.match(r'^\d+$', index)
+        if is_number:
+            escaped_path = escaped_path.replace(f"[{index}]", f"\\[({index})\\]")
+            continue
         escaped_path = escaped_path.replace(f"[{index}]", r"\[(\d+)\]")
     
     # Replace wildcards with a regex pattern that matches and group any string
@@ -34,6 +39,7 @@ def create_regex_from_path(path):
     
     # Create the regex pattern
     regex_pattern = f"^{escaped_path}$"
+    
     return {
         "regex": regex_pattern,
         "indices": indices
@@ -79,7 +85,7 @@ def match_path(path, regex, indices, **kwargs):
     return {
         "match": match,
         "indices": {
-            indices[i]: matched_indices[i] if matched_indices else None
+            indices[i]: matched_indices[i] if matched_indices and i < len(matched_indices) else None
             for i in range(len(indices))
         },
         "wildcards": wildcards
@@ -140,7 +146,7 @@ def map_json(data, mapping, verbose=False):
         # Match the flattened keys against the regex
         for key in flattened_data.keys():
             match_result = match_path(key, **path_regex)
-            if verbose: print(f"Matching key '{key}' against regex: {match_result}")
+            if verbose: print(f"Matching key '{key}' against regex {path_regex}: {match_result}")
             if match_result['match']:
                 # Resolve the 'to' path with matched indices
                 resolved_to_path = resolve_path(to_path, **match_result)

--- a/src/framework/visualisation/react/ui/pages/user_donations_page.tsx
+++ b/src/framework/visualisation/react/ui/pages/user_donations_page.tsx
@@ -79,14 +79,6 @@ function DonationPackage({ donation }: {
         </div>
       </div>
       <div className="flex justify-between items-center text-sm">
-        {/* <a
-          href={`?username=${username}&timestamp=${donation.timestamp}&platform=${donation.platform}&review=true`}
-          rel="noreferrer"
-          className="flex items-center gap-2 text-primary hover:text-primarydark transition-all justify-center"
-        >
-          <BsClipboardData />
-          <span>Summary</span>
-        </a> */}
         <button
           type="button"
           className="flex items-center gap-2 hover:text-primarydark transition-all text-text underline disabled:cursor-not-allowed justify-center"


### PR DESCRIPTION
This pull request refines how JSON files are processed into data tables, enhance regex creation and matching, and remove commented-out code in the user donations page.

### Data processing improvements:
* [`src/framework/processing/py/port/flows/common.py`](diffhunk://#diff-e55b93e663ed56e6cf371fd688eb46160584e52e31d4cbe8a9e690b343a62bc8L261-L285): Updated the `zip_to_data_tables` function to iterate over tables instead of the files in the `zip` so multiple tables can be iterated per file.

### Regex handling enhancements:
* [`src/framework/processing/py/port/flows/utils/flat_json/map_json.py`](diffhunk://#diff-f3026477ffdc6b5d4dc1c91a071b40d49eab2ad7030db152841a17030fdccf9dR30-R42): Modified `create_regex_from_path` to preserve literal numeric indices while still matching wildcard patterns. This allow arrays with multiple entities to convert to multiple tables.
* [`src/framework/processing/py/port/flows/utils/flat_json/map_json.py`](diffhunk://#diff-f3026477ffdc6b5d4dc1c91a071b40d49eab2ad7030db152841a17030fdccf9dL82-R88): Updated `match_path` to handle cases where `matched_indices` may be shorter than `indices`, avoiding potential out-of-range errors.

### UI cleanup:
* [`src/framework/visualisation/react/ui/pages/user_donations_page.tsx`](diffhunk://#diff-0c4ca047fda0a9765cd45274bd1d51c88ae4a6c8d42eab0c8b06f2509a118dcdL82-L89): Removed unused commented-out code related to a summary link in the `DonationPackage` component.

### Demo

In Facebook's new format, the advertiser data is split into two tables, extracted from two different objects inside an array. In my example, the second table is empty as my data does not actually include any *Interactions you may have had with the advertiser's website, app or store*.

![image](https://github.com/user-attachments/assets/27539b4d-9821-4008-8d6a-a6cfe45da1c5)
